### PR TITLE
Implement simple CLI for guia tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
 # Automatizacion
+
+Este repositorio contiene un pequeño script en Python para llevar el control de guías.
+
+## Requisitos
+
+- Python 3.8 o superior
+
+## Uso
+
+Agregar una guía:
+
+```
+python guia_control.py add <id> <valor> <estado>
+```
+
+Actualizar el estado de una guía:
+
+```
+python guia_control.py update <id> <estado>
+```
+
+Listar guías registradas:
+
+```
+python guia_control.py list
+```
+
+Estados válidos: `entregado`, `rechazado`, `novedad`, `reprogramado`.
+
+La información se almacena en el archivo `guias.json` en el mismo directorio.

--- a/guia_control.py
+++ b/guia_control.py
@@ -1,0 +1,76 @@
+import argparse
+import json
+import os
+
+DATA_FILE = 'guias.json'
+STATUSES = ['entregado', 'rechazado', 'novedad', 'reprogramado']
+
+
+def load_data():
+    if os.path.exists(DATA_FILE):
+        with open(DATA_FILE, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    return {}
+
+
+def save_data(data):
+    with open(DATA_FILE, 'w', encoding='utf-8') as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+
+
+def add(args):
+    data = load_data()
+    if args.id in data:
+        print(f"La guía {args.id} ya existe.")
+        return
+    data[args.id] = {'valor': args.valor, 'estado': args.estado}
+    save_data(data)
+    print(f"Guía {args.id} agregada.")
+
+
+def update(args):
+    data = load_data()
+    if args.id not in data:
+        print(f"La guía {args.id} no existe.")
+        return
+    data[args.id]['estado'] = args.estado
+    save_data(data)
+    print(f"Guía {args.id} actualizada.")
+
+
+def list_guias(args):
+    data = load_data()
+    if not data:
+        print('No hay guías registradas.')
+        return
+    for gid, info in data.items():
+        print(f"{gid}: valor {info['valor']} - estado {info['estado']}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Control de guías')
+    sub = parser.add_subparsers(dest='command')
+
+    parser_add = sub.add_parser('add', help='Agregar nueva guía')
+    parser_add.add_argument('id', help='ID de la guía')
+    parser_add.add_argument('valor', type=float, help='Valor total de la guía')
+    parser_add.add_argument('estado', choices=STATUSES, help='Estado inicial de la guía')
+    parser_add.set_defaults(func=add)
+
+    parser_update = sub.add_parser('update', help='Actualizar estado de guía')
+    parser_update.add_argument('id', help='ID de la guía')
+    parser_update.add_argument('estado', choices=STATUSES, help='Nuevo estado de la guía')
+    parser_update.set_defaults(func=update)
+
+    parser_list = sub.add_parser('list', help='Listar guías')
+    parser_list.set_defaults(func=list_guias)
+
+    args = parser.parse_args()
+    if not hasattr(args, 'func'):
+        parser.print_help()
+        return
+    args.func(args)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `guia_control.py` with commands to add, update and list guías
- document how to use the script in Spanish README

## Testing
- `python3 -m py_compile guia_control.py`


------
https://chatgpt.com/codex/tasks/task_e_68766ea971908330bd9eaed7627a483e